### PR TITLE
Release v2 - `Autodesk.Authentication` documentation.

### DIFF
--- a/authentication/source/Autodesk.Authentication.csproj
+++ b/authentication/source/Autodesk.Authentication.csproj
@@ -10,6 +10,7 @@
     <PackageVersion>2.0.0-beta</PackageVersion>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
    <RepositoryUrl>https://github.com/autodesk-platform-services/aps-sdk-net.git</RepositoryUrl>
   </PropertyGroup>
     <ItemGroup>

--- a/authentication/source/Http/TokenApi.gen.cs
+++ b/authentication/source/Http/TokenApi.gen.cs
@@ -126,7 +126,7 @@ namespace Autodesk.Authentication.Http
         /// </remarks>
         /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>
@@ -190,7 +190,7 @@ namespace Autodesk.Authentication.Http
         /// </remarks>
         /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>
@@ -238,7 +238,7 @@ namespace Autodesk.Authentication.Http
         ///
         /// </param>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>
@@ -463,7 +463,7 @@ namespace Autodesk.Authentication.Http
         /// </remarks>
         /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>
@@ -674,7 +674,7 @@ namespace Autodesk.Authentication.Http
         /// </remarks>
         /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>
@@ -798,7 +798,7 @@ namespace Autodesk.Authentication.Http
         ///
         /// </param>
         /// <param name="authorization">
-        ///Must be `Bearer <BASE64_ENCODED_STRING>` where `<BASE64_ENCODED_STRING>` is the Base64 encoding of the concatenated string `<CLIENT_ID>:<CLIENT_SECRET>`.'
+        ///Must be `Bearer &lt;BASE64_ENCODED_STRING&gt;` where `&lt;BASE64_ENCODED_STRING&gt;` is the Base64 encoding of the concatenated string `&lt;CLIENT_ID&gt;:&lt;CLIENT_SECRET&gt;`.'
         ///
         ///**Note** This header is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>

--- a/authentication/source/Http/TokenApi.gen.cs
+++ b/authentication/source/Http/TokenApi.gen.cs
@@ -383,7 +383,7 @@ namespace Autodesk.Authentication.Http
         ///
         ///The string can only contain alphanumeric characters, commas, periods, underscores, and hyphens.             (optional)
         /// </param>
-        /// <param name="scope">
+        /// <param name="scopes">
         ///A URL-encoded space-delimited list of requested scopes. See the [Developer's Guide documentation on scopes](/en/docs/oauth/v2/developers_guide/scopes/) for a list of valid values you can provide.
         ///
         ///The string you specify for this parameter must not exceed 2000 characters and it cannot contain more than 50 scopes.   (optional)

--- a/authentication/source/Http/UsersApi.gen.cs
+++ b/authentication/source/Http/UsersApi.gen.cs
@@ -59,7 +59,9 @@ namespace Autodesk.Authentication.Http
     {
         ILogger logger;
 
-        // Manually added because UsersApi has a different base address.
+        /// <summary>
+        /// Manually added because UsersApi has a different base address.
+        /// </summary>
         public Uri BaseAddress { get; set; }
 
         /// <summary>

--- a/authentication/source/Model/ThreeLeggedToken.gen.cs
+++ b/authentication/source/Model/ThreeLeggedToken.gen.cs
@@ -78,7 +78,7 @@ namespace Autodesk.Authentication.Model
 
         /// <summary>
         /// Time the access token will expire at, in Unix seconds.
-        ////// </summary>
+        /// </summary>
         /// <value>
         ///Time the access token will expire at, in Unix seconds.
         /// </value>

--- a/authentication/source/custom-code/AuthenticationClient.cs
+++ b/authentication/source/custom-code/AuthenticationClient.cs
@@ -203,7 +203,7 @@ namespace Autodesk.Authentication
         ///The Client secret of the calling application, as registered with APS.
         ///**Note** The clientSecret is required only for Traditional Web Apps and Server-to-Server Apps. It is not required for Desktop, Mobile, and Single-Page Apps. (optional)
         /// </param>             
-        /// <param name="refresh_token">
+        /// <param name="refreshToken">
         ///The refresh token used to acquire a new access token and a refresh token.     
         /// </param> 
         /// <param name="scopes">

--- a/authentication/test/TestAuthentication.cs
+++ b/authentication/test/TestAuthentication.cs
@@ -60,7 +60,7 @@ public class TestAuthentication
     [TestMethod]
     public async Task TestRefreshTokenAsync()
     {
-        RefreshToken newToken = await _authClient.GetRefreshTokenAsync(client_id, client_secret, "refreshToken");
+        ThreeLeggedToken newToken = await _authClient.RefreshTokenAsync(client_id, client_secret, "refreshToken");
         Assert.IsNotNull(newToken.AccessToken);
     }
 


### PR DESCRIPTION
Enable `GenerateDocumentationFile` in the `Autodesk.Authentication` project to have documentation references in the package.


