### PR TITLE
Release v2 - Reorder `RefreshTokenAsync`

### DIFF
--- a/authentication/source/custom-code/AuthenticationClient.cs
+++ b/authentication/source/custom-code/AuthenticationClient.cs
@@ -211,7 +211,7 @@ namespace Autodesk.Authentication
         ///If specified, scopes have to be primarily same with or a subset of the scopes used to generate the refresh_token.(optional)
         /// </param>   
         /// <returns>Task of  &lt;ThreeLeggedToken&gt;</returns>
-        public async System.Threading.Tasks.Task<ThreeLeggedToken> RefreshTokenAsync(string clientId, string clientSecret, string refreshToken, List<Scopes> scopes = null, bool throwOnError = true)
+        public async System.Threading.Tasks.Task<ThreeLeggedToken> RefreshTokenAsync(string refreshToken, string clientId, string clientSecret = default(string), List<Scopes> scopes = null, bool throwOnError = true)
         {
 
             if (!string.IsNullOrEmpty(clientSecret))

--- a/authentication/test/TestAuthentication.cs
+++ b/authentication/test/TestAuthentication.cs
@@ -60,7 +60,7 @@ public class TestAuthentication
     [TestMethod]
     public async Task TestRefreshTokenAsync()
     {
-        ThreeLeggedToken newToken = await _authClient.RefreshTokenAsync(client_id, client_secret, "refreshToken");
+        ThreeLeggedToken newToken = await _authClient.RefreshTokenAsync("refreshToken", client_id, client_secret);
         Assert.IsNotNull(newToken.AccessToken);
     }
 

--- a/samples/authentication.cs
+++ b/samples/authentication.cs
@@ -74,7 +74,7 @@ namespace Samples
                   // Get Refresh token
                   try
                   {
-                        ThreeLeggedToken newToken = await authenticationClient.RefreshTokenAsync(client_id, client_secret, "refreshToken");
+                        ThreeLeggedToken newToken = await authenticationClient.RefreshTokenAsync("refreshToken", client_id, client_secret);
                         string accessToken = newToken.AccessToken;
 
                   }


### PR DESCRIPTION
Reorder `RefreshTokenAsync` method to have the token first to work the same way as `IntrospectTokenAsync` and `RevokeAsync`.

Set `clientSecret` as optional.

```c#
RevokeAsync("token", client_id, client_secret);
IntrospectTokenAsync("token", client_id, client_secret);
RefreshTokenAsync("refreshToken", client_id, client_secret);
```

