### PR TITLE
Update nuget.config To Reference nuget.org

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Local" value="./samples/packages" />
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Updated nuget.config to reference nuget.org instead of local packages since they were removed because of Package Restore in [Commit 2d97c7f](https://github.com/autodesk-platform-services/aps-sdk-net/commit/2d97c7f466ee6bce16e619c717f9d7854b27f6fe)