### PR TITLE
Bump Autodesk.Forge.Core Version 4.0.0 To 4.1.1

### DIFF
--- a/sdkmanager/Autodesk.Sdk.Manager.csproj
+++ b/sdkmanager/Autodesk.Sdk.Manager.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/autodesk-platform-services/aps-sdk-net.git</RepositoryUrl>
   </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Autodesk.Forge.Core" Version="4.0.0" />
+      <PackageReference Include="Autodesk.Forge.Core" Version="4.1.1" />
       <None Include="LICENSE.txt" Pack="true" PackagePath=""/>
       <None Include="README.md" Pack="true" PackagePath=""/>
     </ItemGroup>


### PR DESCRIPTION
Bump Autodesk.Forge.Core version 4.0.0 to 4.1.1 in Autodesk.Sdk.Manager.csproj file to resolve dependencies on vulnerable packages. This was resolved in [PR #184](https://github.com/Autodesk-Forge/forge-api-dotnet-core/pull/184) of the [Autodesk.Forge.Core](https://github.com/Autodesk-Forge/forge-api-dotnet-core) repo & released in version 4.1.1 ([GitHub](https://github.com/Autodesk-Forge/forge-api-dotnet-core/releases/tag/v4.1.1), [nuget](https://www.nuget.org/packages/Autodesk.Forge.Core/4.1.1)).

![image](https://github.com/user-attachments/assets/4c5c1639-f874-4e13-b5cd-9d83a382f81c)
