### PR TITLE
Typo, extensions should be extension

### DIFF
--- a/datamanagement/source/Model/TopFolderAttributesWithExtensions.gen.cs
+++ b/datamanagement/source/Model/TopFolderAttributesWithExtensions.gen.cs
@@ -148,8 +148,8 @@ namespace Autodesk.DataManagement.Model
         /// <summary>
         ///Gets or Sets Extensions
         /// </summary>
-        [DataMember(Name="extensions", EmitDefaultValue=false)]
-        public TopFolderExtensionWithSchemaLink Extensions { get; set; }
+        [DataMember(Name="extension", EmitDefaultValue=false)]
+        public TopFolderExtensionWithSchemaLink Extension { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object


### PR DESCRIPTION
A typo is causing extension of topfolder endpoint not to be serialized.

Which in turn leads to not being able to see if this is a root folder or not e.g.

After running for a while on custom assemblies we wanted to test the new released Autodesk nuget packages after seing our pull requests was merged. Experiencing this is a showstopper. Can we get a quick beta release for this?

Fixes #124 