### PR TITLE
Add User Projects api & test.

### DIFF
--- a/construction/accountadmin/accountadmin.sln
+++ b/construction/accountadmin/accountadmin.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autodesk.Construction.AccountAdmin.Test", "test\Autodesk.Construction.AccountAdmin.Test.csproj", "{B5CF67B7-61DF-4C10-9443-40F36F1F3BBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autodesk.Construction.AccountAdmin", "source\Autodesk.Construction.AccountAdmin.csproj", "{EFA9B2AB-581B-9313-1A40-A41F7663E437}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B5CF67B7-61DF-4C10-9443-40F36F1F3BBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5CF67B7-61DF-4C10-9443-40F36F1F3BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5CF67B7-61DF-4C10-9443-40F36F1F3BBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5CF67B7-61DF-4C10-9443-40F36F1F3BBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFA9B2AB-581B-9313-1A40-A41F7663E437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFA9B2AB-581B-9313-1A40-A41F7663E437}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFA9B2AB-581B-9313-1A40-A41F7663E437}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFA9B2AB-581B-9313-1A40-A41F7663E437}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A57C34B3-572B-42C3-BC97-6A0AD95C207D}
+	EndGlobalSection
+EndGlobal

--- a/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
+++ b/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
@@ -108,7 +108,7 @@ namespace Autodesk.Construction.AccountAdmin.Http
         /// <returns>
         /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
         /// </returns>        
-        System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync (string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true);
+        System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync(string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true);
     }
 
     /// <summary>
@@ -279,8 +279,7 @@ namespace Autodesk.Construction.AccountAdmin.Http
         /// <returns>
         /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
         /// </returns>    
-        public async System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync(
-				string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true)
+        public async System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync(string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true)
         {
             logger.LogInformation($"Entered into {nameof(GetUserProjectsAsync)}");
 			   using HttpRequestMessage request = new();

--- a/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
+++ b/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
@@ -108,27 +108,7 @@ namespace Autodesk.Construction.AccountAdmin.Http
         /// <returns>
         /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
         /// </returns>        
-        System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync (
-            string accountId, 
-            string acceptLanguage= default,
-            Region? region= null,
-            string userId= default,
-			   List<string> filterId = default,
-            List<Fields> fields= default,
-			   List<Classification> filterClassification= default,
-            string filterName= default,
-            List<Platform> filterPlatform= default,
-            List<Status> filterStatus= default,
-            List<string> filterType= default,
-            string filterJobNumber= default,
-            string filterUpdatedAt= default,
-			   List<AccessLevels> filterAccessLevels = default,
-			   FilterTextMatch? filterTextMatch= null,
-            List<SortBy> sort= default,
-            int? limit= default,
-            int? offset= default,
-            string accessToken = null,
-            bool throwOnError = true);
+        System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync (string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true);
     }
 
     /// <summary>
@@ -300,26 +280,7 @@ namespace Autodesk.Construction.AccountAdmin.Http
         /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
         /// </returns>    
         public async System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync(
-				string accountId,
-				string acceptLanguage = default,
-				Region? region = null,
-				string userId = default,
-				List<string> filterId = default,
-				List<Fields> fields = default,
-				List<Classification> filterClassification = default,
-				string filterName = default,
-				List<Platform> filterPlatform = default,
-				List<Status> filterStatus = default,
-				List<string> filterType = default,
-				string filterJobNumber = default,
-				string filterUpdatedAt = default,
-				List<AccessLevels> filterAccessLevels = default,
-				FilterTextMatch? filterTextMatch = null,
-				List<SortBy> sort = default,
-				int? limit = default,
-				int? offset = default,
-				string accessToken = null,
-				bool throwOnError = true)
+				string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true)
         {
             logger.LogInformation($"Entered into {nameof(GetUserProjectsAsync)}");
 			   using HttpRequestMessage request = new();

--- a/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
+++ b/construction/accountadmin/source/Http/UserProjectsApi.gen.cs
@@ -1,0 +1,417 @@
+/* 
+ * APS SDK
+ *
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Construction.Account.Admin
+ *
+ * The Account Admin API automates creating and managing projects, assigning and managing project users, and managing member and partner company directories. You can also synchronize data with external systems. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using Autodesk.Forge.Core;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.Serialization;
+using Autodesk.Construction.AccountAdmin.Model;
+using Autodesk.Construction.AccountAdmin.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Autodesk.SDKManager;
+using System.Collections;
+using System.IO;
+
+namespace Autodesk.Construction.AccountAdmin.Http
+{
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints.
+    /// </summary>
+    public interface IUserProjectsApi
+    {
+        /// <summary>
+        /// Get projects of user in account.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of the projects in the specified account.
+        /// </remarks>
+        /// <exception cref="HttpRequestException">
+        /// Thrown when fails to make API call.
+        /// </exception>
+        /// <param name="accountId">
+        /// The ID of the ACC account that contains the project being created or the projects being retrieved. This corresponds to the hub ID in the Data Management API. To convert a hub ID into an account ID, remove the “b.” prefix. For example, a hub ID of b.c8b0c73d-3ae9 translates to an account ID of c8b0c73d-3ae9.
+        /// </param>
+        /// <param name="acceptLanguage">
+        /// This header is not currently supported in the Account Admin API. (optional)
+        /// </param>
+        /// <param name="region">
+        /// The region where the bucket resides. Acceptable values: US, EMEA, AUS. (optional)
+        /// </param>
+        /// <param name="userId">
+        /// Note that this header is not relevant for Account Admin GET endpoints. The ID of a user on whose behalf your API request is acting. Required if you’re using a 2-legged authentication context, which must be 2-legged OAuth2 security with user impersonation.  Your app has access to all users specified by the administrator in the SaaS integrations UI. Provide this header value to identify the user to be affected by the request.  You can use either the user’s ACC ID (id), or their Autodesk ID (autodeskId). (optional)
+        /// </param>
+        /// <param name="filterId">
+        /// A list of the ACC IDs of users to retrieve. (optional)
+        /// </param>
+        /// <param name="fields">
+        /// A comma-separated list of the project fields to include in the response. Default value: all fields. (optional)
+        /// </param>
+        /// <param name="filterClassification">
+        /// A list of the classifications of projects to include in the response. Possible values: production, template, component, sample. (optional)
+        /// </param>
+        /// <param name="filterName">
+        /// A project name or name pattern to filter projects by. Can be a partial match based on the value of filterTextMatch that you provide; for example: filter[name]=ABCco filterTextMatch=startsWith.  Max length: 255 (optional)
+        /// </param>
+        /// <param name="filterPlatform">
+        /// Filter resource by platform. Possible values: acc and bim360. (optional)
+        /// </param>
+        /// <param name="filterStatus">
+        /// A list of the statuses of projects to include in the response. Possible values:  active, pending, archived, suspended. (optional)
+        /// </param>
+        /// <param name="filterType">
+        /// A list of project types to filter projects by. To exclude a project type from the response, prefix it with - (a hyphen); for example, -Bridge excludes bridge projects. (optional)
+        /// </param>
+        /// <param name="filterJobNumber">
+        /// The user-defined identifier for a project to be returned. This ID was defined when the project was created. This filter accepts a partial match based on the value of filterTextMatch that you provide. (optional)
+        /// </param>
+        /// <param name="filterUpdatedAt">
+        /// A range of dates during which the desired projects were updated. The range must be specified with dates in ISO 8601 format with time required. Separate multiple values with commas. (optional)
+        /// </param>
+        /// <param name="filterAccessLevels">
+        ///A list of user access levels that the returned users must have. (optional)
+        /// </param>
+        /// <param name="filterTextMatch">
+        /// When filtering on a text-based field, this value indicates how to do the matching. Default value: contains. Possible values: contains, startsWith, endsWith and equals. (optional)
+        /// </param>
+        /// <param name="sort">
+        /// A list of fields to sort the returned projects by. Multiple sort fields are applied in sequence order — each sort field produces groupings of projects with the same values of that field; the next sort field applies within the groupings produced by the previous sort field. (optional)
+        /// </param>
+        /// <param name="limit">
+        ///The maximum number of records to return in a single request. Possible range: 1-200. Default value: 20. (optional)
+        /// </param>
+        /// <param name="offset">
+        /// The record number that the returned page should start with. When the total number of records exceeds the value of limit, increase the offset value in subsequent requests to continue getting the remaining results. (optional)
+        /// </param>
+        /// <returns>
+        /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
+        /// </returns>        
+        System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync (
+            string accountId, 
+            string acceptLanguage= default,
+            Region? region= null,
+            string userId= default,
+			   List<string> filterId = default,
+            List<Fields> fields= default,
+			   List<Classification> filterClassification= default,
+            string filterName= default,
+            List<Platform> filterPlatform= default,
+            List<Status> filterStatus= default,
+            List<string> filterType= default,
+            string filterJobNumber= default,
+            string filterUpdatedAt= default,
+			   List<AccessLevels> filterAccessLevels = default,
+			   FilterTextMatch? filterTextMatch= null,
+            List<SortBy> sort= default,
+            int? limit= default,
+            int? offset= default,
+            string accessToken = null,
+            bool throwOnError = true);
+    }
+
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints.
+    /// </summary>
+    public partial class UserProjectsApi : IUserProjectsApi
+	 {
+        private ILogger logger;
+
+        /// <summary>
+        /// Gets or sets the ApsConfiguration object.
+        /// </summary>
+        /// <value>
+        /// An instance of the ForgeService.
+        /// </value>
+        public ForgeService Service {get; set;}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProjectsApi"/> class using SDKManager object.
+        /// </summary>
+        /// <param name="sdkManager">
+        /// An instance of SDKManager.
+        /// </param>
+        /// <returns></returns>
+        public UserProjectsApi(SDKManager.SDKManager sdkManager)
+        {
+            logger = sdkManager.Logger;
+            Service = sdkManager.ApsClient.Service;
+        }
+
+        private void SetQueryParameter(string name, object value, Dictionary<string, object> dictionary)
+        {
+            if(value is Enum)
+            {
+                var type = value.GetType();
+                var memberInfos = type.GetMember(value.ToString());
+                var enumValueMemberInfo = memberInfos.FirstOrDefault(m => m.DeclaringType == type);
+                var valueAttributes = enumValueMemberInfo.GetCustomAttributes(typeof(EnumMemberAttribute), false);
+                if(valueAttributes.Length > 0)
+                {
+                    dictionary.Add(name, ((EnumMemberAttribute)valueAttributes[0]).Value);
+                }
+            }
+            else if(value is int)
+            {
+                if((int)value > 0)
+                {
+                    dictionary.Add(name, value);
+                }
+            }
+            else if (value is IList)
+            {
+                if (value is List<string>)
+                {
+                    value = string.Join(",",(List<string>)value);
+                    dictionary.Add(name, value);
+                }
+                else 
+                {
+                    List<string>newlist = [];
+                    foreach ( var x in (IList)value)
+                    {
+                        var type = x.GetType();
+                        var memberInfos = type.GetMember(x.ToString());
+                        var enumValueMemberInfo = memberInfos.FirstOrDefault(m => m.DeclaringType == type);
+                        var valueAttributes = enumValueMemberInfo.GetCustomAttributes(typeof(EnumMemberAttribute), false);
+                        newlist.Add(((EnumMemberAttribute)valueAttributes[0]).Value);                            
+                    }
+                    string joinedString = string.Join(",", newlist);
+                    dictionary.Add(name, joinedString);
+                }
+            }
+            else
+            {
+                if(value != null)
+                {
+                    dictionary.Add(name, value);
+                }
+            }
+        }
+
+        private void SetHeader(string baseName, object value, HttpRequestMessage req)
+        {
+            if(value is DateTime)
+            {
+                if((DateTime)value != DateTime.MinValue)
+                {
+                    req.Headers.TryAddWithoutValidation(baseName, LocalMarshalling.ParameterToString(value)); // header parameter
+                }
+            }
+            else
+            {
+                if (value != null)
+                {
+                    if(!string.Equals(baseName, "Content-Range"))
+                    {
+                        req.Headers.TryAddWithoutValidation(baseName, LocalMarshalling.ParameterToString(value)); // header parameter
+                    }
+                    else
+                    {
+                        req.Content.Headers.Add(baseName, LocalMarshalling.ParameterToString(value));
+                    }
+                }
+            }
+        }
+      
+        /// <summary>
+        /// Get projects of user in account.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of the projects in the specified account.
+        /// </remarks>
+        /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
+        /// <param name="accountId">
+        /// The ID of the ACC account that contains the project being created or the projects being retrieved. This corresponds to the hub ID in the Data Management API. To convert a hub ID into an account ID, remove the “b.” prefix. For example, a hub ID of b.c8b0c73d-3ae9 translates to an account ID of c8b0c73d-3ae9.
+        /// </param>
+        /// <param name="acceptLanguage">
+        /// This header is not currently supported in the Account Admin API. (optional)
+        /// </param>
+        /// <param name="region">
+        /// The region where the bucket resides. Acceptable values: US, EMEA, AUS. (optional)
+        /// </param>
+        /// <param name="userId">
+        /// Note that this header is not relevant for Account Admin GET endpoints. The ID of a user on whose behalf your API request is acting. Required if you’re using a 2-legged authentication context, which must be 2-legged OAuth2 security with user impersonation.  Your app has access to all users specified by the administrator in the SaaS integrations UI. Provide this header value to identify the user to be affected by the request.  You can use either the user’s ACC ID (id), or their Autodesk ID (autodeskId). (optional)
+        /// </param>
+        /// <param name="filterId">
+        /// A list of the ACC IDs of users to retrieve. (optional)
+        /// </param>
+        /// <param name="fields">
+        /// A comma-separated list of the project fields to include in the response. Default value: all fields. (optional)
+        /// </param>
+        /// <param name="filterClassification">
+        /// A list of the classifications of projects to include in the response. Possible values: production, template, component, sample. (optional)
+        /// </param>
+        /// <param name="filterName">
+        /// A project name or name pattern to filter projects by. Can be a partial match based on the value of filterTextMatch that you provide; for example: filter[name]=ABCco filterTextMatch=startsWith.  Max length: 255 (optional)
+        /// </param>
+        /// <param name="filterPlatform">
+        /// Filter resource by platform. Possible values: acc and bim360. (optional)
+        /// </param>
+        /// <param name="filterStatus">
+        /// A list of the statuses of projects to include in the response. Possible values:  active pending archived suspended (optional)
+        /// </param>
+        /// <param name="filterType">
+        /// A list of project types to filter projects by. To exclude a project type from the response, prefix it with - (a hyphen); for example, -Bridge excludes bridge projects. (optional)
+        /// </param>
+        /// <param name="filterJobNumber">
+        /// The user-defined identifier for a project to be returned. This ID was defined when the project was created. This filter accepts a partial match based on the value of filterTextMatch that you provide. (optional)
+        /// </param>
+        /// <param name="filterUpdatedAt">
+        /// A range of dates during which the desired projects were updated. The range must be specified with dates in ISO 8601 format with time required. Separate multiple values with commas. (optional)
+        /// </param>
+        /// <param name="filterAccessLevels">
+        ///A list of user access levels that the returned users must have. (optional)
+        /// </param>
+        /// <param name="filterTextMatch">
+        /// When filtering on a text-based field, this value indicates how to do the matching. Default value: contains. Possible values: contains, startsWith, endsWith and equals. (optional)
+        /// </param>
+        /// <param name="sort">
+        /// A list of fields to sort the returned projects by. Multiple sort fields are applied in sequence order — each sort field produces groupings of projects with the same values of that field; the next sort field applies within the groupings produced by the previous sort field. (optional)
+        /// </param>
+        /// <param name="limit">
+        ///The maximum number of records to return in a single request. Possible range: 1-200. Default value: 20. (optional)
+        /// </param>
+        /// <param name="offset">
+        /// The record number that the returned page should start with. When the total number of records exceeds the value of limit, increase the offset value in subsequent requests to continue getting the remaining results. (optional)
+        /// </param>
+        /// <returns>
+        /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="ApiResponse"/>&lt;<see cref="UserProjects"/>&gt;&gt;
+        /// </returns>    
+        public async System.Threading.Tasks.Task<ApiResponse<UserProjects>> GetUserProjectsAsync(
+				string accountId,
+				string acceptLanguage = default,
+				Region? region = null,
+				string userId = default,
+				List<string> filterId = default,
+				List<Fields> fields = default,
+				List<Classification> filterClassification = default,
+				string filterName = default,
+				List<Platform> filterPlatform = default,
+				List<Status> filterStatus = default,
+				List<string> filterType = default,
+				string filterJobNumber = default,
+				string filterUpdatedAt = default,
+				List<AccessLevels> filterAccessLevels = default,
+				FilterTextMatch? filterTextMatch = null,
+				List<SortBy> sort = default,
+				int? limit = default,
+				int? offset = default,
+				string accessToken = null,
+				bool throwOnError = true)
+        {
+            logger.LogInformation($"Entered into {nameof(GetUserProjectsAsync)}");
+			   using HttpRequestMessage request = new();
+			   Dictionary<string, object> queryParam = [];
+			   SetQueryParameter("filter[id]", filterId, queryParam);
+			   SetQueryParameter("fields", fields, queryParam);
+			   SetQueryParameter("filter[classification]", filterClassification, queryParam);
+			   SetQueryParameter("filter[name]", filterName, queryParam);
+			   SetQueryParameter("filter[platform]", filterPlatform, queryParam);
+			   SetQueryParameter("filter[status]", filterStatus, queryParam);
+			   SetQueryParameter("filter[type]", filterType, queryParam);
+			   SetQueryParameter("filter[jobNumber]", filterJobNumber, queryParam);
+			   SetQueryParameter("filter[updatedAt]", filterUpdatedAt, queryParam);
+			   SetQueryParameter("filter[accessLevels]", filterAccessLevels, queryParam);
+			   SetQueryParameter("filterTextMatch", filterTextMatch, queryParam);
+			   SetQueryParameter("sort", sort, queryParam);
+			   SetQueryParameter("limit", limit, queryParam);
+			   SetQueryParameter("offset", offset, queryParam);
+			   request.RequestUri =
+				    Marshalling.BuildRequestUri("/construction/admin/v1/accounts/{accountId}/users/{userId}/projects",
+					     routeParameters: new Dictionary<string, object> {
+						      { "accountId", accountId},
+								{ "userId", userId},
+					     },
+					     queryParameters: queryParam
+				    );
+
+			   request.Headers.TryAddWithoutValidation("Accept", "application/json");
+			   request.Headers.TryAddWithoutValidation("User-Agent", "APS SDK/CONSTRUCTION.ACCOUNT.ADMIN/C#/1.0.0");
+			   if (!string.IsNullOrEmpty(accessToken))
+			   {
+				    request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+			   }
+
+
+
+			   SetHeader("Accept-Language", acceptLanguage, request);
+			   SetHeader("Region", region, request);
+			   SetHeader("User-Id", userId, request);
+
+			   // tell the underlying pipeline what scope we'd like to use
+			   // if (scopes == null)
+			   // {
+			   // TBD:Naren FORCE-4027 - If accessToken is null, acquire auth token using auth SDK, with defined scope.
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), "");
+			   // }
+			   // else
+			   // {
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), scopes);
+			   // }
+			   // if (scopes == null)
+			   // {
+			   // TBD:Naren FORCE-4027 - If accessToken is null, acquire auth token using auth SDK, with defined scope.
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), "");
+			   // }
+			   // else
+			   // {
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), scopes);
+			   // }
+			   // if (scopes == null)
+			   // {
+			   // TBD:Naren FORCE-4027 - If accessToken is null, acquire auth token using auth SDK, with defined scope.
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), "");
+			   // }
+			   // else
+			   // {
+			   // request.Properties.Add(ForgeApsConfiguration.ScopeKey.ToString(), scopes);
+			   // }
+
+			   request.Method = new HttpMethod("GET");
+
+			   // make the HTTP request
+			   var response = await Service.Client.SendAsync(request);
+
+			   if (throwOnError)
+			   {
+				    try
+				    {
+					     await response.EnsureSuccessStatusCodeAsync();
+				    }
+				    catch (HttpRequestException ex)
+				    {
+					     throw new ConstructionAccountAdminApiException(ex.Message, response, ex);
+				    }
+			   }
+			   else if (!response.IsSuccessStatusCode)
+			   {
+				    logger.LogError($"Response unsuccess with status code: {response.StatusCode}");
+				    return new ApiResponse<UserProjects>(response, default);
+			   }
+			   logger.LogInformation($"Exited from {nameof(GetUserProjectsAsync)} with response statusCode: {response.StatusCode}");
+			   return new ApiResponse<UserProjects>(response, await LocalMarshalling.DeserializeAsync<UserProjects>(response.Content));
+		  }
+    }
+}

--- a/construction/accountadmin/source/Model/UserProject.gen.cs
+++ b/construction/accountadmin/source/Model/UserProject.gen.cs
@@ -1,0 +1,336 @@
+/* 
+ * APS SDK
+ *
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Construction.Account.Admin
+ *
+ * The Account Admin API automates creating and managing projects, assigning and managing project users, and managing member and partner company directories. You can also synchronize data with external systems. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Autodesk.Construction.AccountAdmin.Model
+{
+    /// <summary>
+    /// User Project
+    /// </summary>
+    [DataContract]
+    public partial class UserProject
+	{
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProject" /> class.
+        /// </summary>
+        public UserProject()
+        { }
+        
+        /// <summary>
+        /// The internally generated ID for the project.
+        /// </summary>
+        /// <value>
+        /// The internally generated ID for the project.
+        /// </value>
+        [DataMember(Name="id", EmitDefaultValue=false)]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the project.
+        /// Max length: 255
+        /// </summary>
+        /// <value>
+        /// The name of the project.
+        /// Max length: 255
+        /// </value>
+        [DataMember(Name="name", EmitDefaultValue=false)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The estimated start date for the project, in ISO 8601 format.
+        /// </summary>
+        /// <value>
+        /// The estimated start date for the project, in ISO 8601 format.
+        /// </value>
+        [DataMember(Name="startDate", EmitDefaultValue=false)]
+        public string StartDate { get; set; }
+
+        /// <summary>
+        /// The estimated end date for the project, in ISO 8601 format.
+        /// </summary>
+        /// <value>
+        /// The estimated end date for the project, in ISO 8601 format.
+        /// </value>
+        [DataMember(Name="endDate", EmitDefaultValue=false)]
+        public string EndDate { get; set; }
+
+        /// <summary>
+        /// The type of the project.
+        /// </summary>
+        /// <value>
+        /// The type of the project.
+        /// </value>
+        [DataMember(Name="type", EmitDefaultValue=false)]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The project’s purpose. Possible values: production, template, component, sample.
+        /// </summary>
+        /// <value>
+        /// The project’s purpose. Possible values: production, template, component, sample.
+        /// </value>
+        [DataMember(Name="classification", EmitDefaultValue=false)]
+        public string Classification { get; set; }
+
+        /// <summary>
+        /// The value of the project. When updating the project value, both the value and currency parameters are required.
+        /// </summary>
+        /// <value>
+        /// The value of the project. When updating the project value, both the value and currency parameters are required.
+        /// </value>
+        [DataMember(Name="projectValue", EmitDefaultValue=false)]
+        public object ProjectValue { get; set; }
+
+        /// <summary>
+        /// The status of the project.
+        /// </summary>
+        /// <value>
+        /// The status of the project.
+        /// </value>
+        [DataMember(Name="status", EmitDefaultValue=false)]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// A job identifier that’s defined for the project by the user. This ID was defined when the project was created.
+        /// Max length: 100
+        /// </summary>
+        /// <value>
+        /// A job identifier that’s defined for the project by the user. This ID was defined when the project was created.
+        /// Max length: 100
+        /// </value>
+        [DataMember(Name="jobNumber", EmitDefaultValue=false)]
+        public string JobNumber { get; set; }
+
+        /// <summary>
+        /// Address line 1 for the project.
+        /// Max length: 255
+        /// </summary>
+        /// <value>
+        /// Address line 1 for the project.
+        /// Max length: 255
+        /// </value>
+        [DataMember(Name="addressLine1", EmitDefaultValue=false)]
+        public string AddressLine1 { get; set; }
+
+        /// <summary>
+        /// Address line 2 for the project.
+        /// Max length: 255
+        /// </summary>
+        /// <value>
+        /// Address line 2 for the project.
+        /// Max length: 255
+        /// </value>
+        [DataMember(Name="addressLine2", EmitDefaultValue=false)]
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// The city in which the project is located.
+        /// </summary>
+        /// <value>
+        /// The city in which the project is located.
+        /// </value>
+        [DataMember(Name="city", EmitDefaultValue=false)]
+        public string City { get; set; }
+
+        /// <summary>
+        /// The state or province in which the project is located. Only valid state/province names and ISO 3166-1 alpha-2 codes is accepted. The provided state or province must exist in the country of the project.
+        /// </summary>
+        /// <value>
+        /// The state or province in which the project is located. Only valid state/province names and ISO 3166-1 alpha-2 codes is accepted. The provided state or province must exist in the country of the project.
+        /// </value>
+        [DataMember(Name="stateOrProvince", EmitDefaultValue=false)]
+        public string StateOrProvince { get; set; }
+
+        /// <summary>
+        /// The zip or postal code in which the project is located.
+        /// </summary>
+        /// <value>
+        /// The zip or postal code in which the project is located.
+        /// </value>
+        [DataMember(Name="postalCode", EmitDefaultValue=false)]
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// The country in which the project is located. Only valid country names and ISO 3166-1 alpha-2 codes is accepted.
+        /// </summary>
+        /// <value>
+        /// The country in which the project is located. Only valid country names and ISO 3166-1 alpha-2 codes is accepted.
+        /// </value>
+        [DataMember(Name="country", EmitDefaultValue=false)]
+        public string Country { get; set; }
+
+        /// <summary>
+        /// The latitude of the location of the project.
+        /// </summary>
+        /// <value>
+        /// The latitude of the location of the project.
+        /// </value>
+        [DataMember(Name="latitude", EmitDefaultValue=false)]
+        public string Latitude { get; set; }
+
+        /// <summary>
+        /// The longitude of the location of the project.
+        /// </summary>
+        /// <value>
+        /// The longitude of the location of the project.
+        /// </value>
+        [DataMember(Name="longitude", EmitDefaultValue=false)]
+        public string Longitude { get; set; }
+
+        /// <summary>
+        /// The time zone in which the project is located. Note that this field can be NULL.
+        /// </summary>
+        /// <value>
+        /// The time zone in which the project is located. Note that this field can be NULL.
+        /// </value>
+        [DataMember(Name="timezone", EmitDefaultValue=false)]
+        public string Timezone { get; set; }
+
+        /// <summary>
+        /// The construction type of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </summary>
+        /// <value>
+        /// The construction type of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </value>
+        [DataMember(Name="constructionType", EmitDefaultValue=false)]
+        public string ConstructionType { get; set; }
+
+        /// <summary>
+        /// The delivery method of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </summary>
+        /// <value>
+        /// The delivery method of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </value>
+        [DataMember(Name="deliveryMethod", EmitDefaultValue=false)]
+        public string DeliveryMethod { get; set; }
+
+        /// <summary>
+        /// The contract type of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </summary>
+        /// <value>
+        /// The contract type of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </value>
+        [DataMember(Name="contractType", EmitDefaultValue=false)]
+        public string ContractType { get; set; }
+
+        /// <summary>
+        /// The current phase of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </summary>
+        /// <value>
+        /// The current phase of the project. Following is a list of recommended values; however, any value is accepted.
+        /// </value>
+        [DataMember(Name="currentPhase", EmitDefaultValue=false)]
+        public string CurrentPhase { get; set; }
+
+        /// <summary>
+        /// The URL of the project image.
+        /// </summary>
+        /// <value>
+        /// The URL of the project image.
+        /// </value>
+        [DataMember(Name="imageUrl", EmitDefaultValue=false)]
+        public string ImageUrl { get; set; }
+
+        /// <summary>
+        /// The URL of the project thumbnail image.
+        /// </summary>
+        /// <value>
+        /// The URL of the project thumbnail image.
+        /// </value>
+        [DataMember(Name="thumbnailImageUrl", EmitDefaultValue=false)]
+        public string ThumbnailImageUrl { get; set; }
+
+        /// <summary>
+        /// The timestamp when the project was created, in ISO 8601 format.
+        /// </summary>
+        /// <value>
+        /// The timestamp when the project was created, in ISO 8601 format.
+        /// </value>
+        [DataMember(Name="createdAt", EmitDefaultValue=false)]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp when the project was last updated, in ISO 8601 format.
+        /// </summary>
+        /// <value>
+        /// The timestamp when the project was last updated, in ISO 8601 format.
+        /// </value>
+        [DataMember(Name="updatedAt", EmitDefaultValue=false)]
+        public string UpdatedAt { get; set; }
+
+        /// <summary>
+        /// The ID of the account the project is associated with.
+        /// </summary>
+        /// <value>
+        /// The ID of the account the project is associated with.
+        /// </value>
+        [DataMember(Name="accountId", EmitDefaultValue=false)]
+        public string AccountId { get; set; }
+
+        /// <summary>
+        /// The total number of sheets associated with the project.
+        /// </summary>
+        /// <value>
+        /// The total number of sheets associated with the project.
+        /// </value>
+        [DataMember(Name="sheetCount", EmitDefaultValue=false)]
+        public int? SheetCount { get; set; }
+
+        /// <summary>
+        /// The APS platform that the project belongs to.
+        /// </summary>
+        /// <value>
+        /// The APS platform that the project belongs to.
+        /// </value>
+        [DataMember(Name="platform", EmitDefaultValue=false)]
+        public string Platform { get; set; }
+
+        /// <summary>
+        /// Gets or Sets AccessLevels.
+        /// </summary>
+        /// <value>
+        /// Gets or Sets AccessLevels.
+        /// </value>
+        [DataMember(Name="accessLevels", EmitDefaultValue=false)]
+        public ProjectUserAccessLevels AccessLevels { get; set; }
+
+        /// <summary>
+        /// Returns the string presentation of the object.
+        /// </summary>
+        /// <returns>
+        /// String presentation of the object.
+        /// </returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+}

--- a/construction/accountadmin/source/Model/UserProjects.gen.cs
+++ b/construction/accountadmin/source/Model/UserProjects.gen.cs
@@ -1,0 +1,77 @@
+/* 
+ * APS SDK
+ *
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Construction.Account.Admin
+ *
+ * The Account Admin API automates creating and managing projects, assigning and managing project users, and managing member and partner company directories. You can also synchronize data with external systems. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Autodesk.Construction.AccountAdmin.Model
+{
+    /// <summary>
+    /// User Projects
+    /// </summary>
+    [DataContract]
+    public partial class UserProjects 
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProjects" /> class.
+        /// </summary>
+        public UserProjects()
+        { }
+        
+        /// <summary>
+        /// Gets or sets pagination.
+        /// </summary>
+        /// <value>
+        /// Gets or sets pagination.
+        /// </value>
+        [DataMember(Name="pagination", EmitDefaultValue=false)]
+        public UserProjectsPagination Pagination { get; set; }
+
+        /// <summary>
+        /// The requested page of the user’s projects.
+        /// </summary>
+        /// <value>
+        /// The requested page of the user’s projects.
+        /// </value>
+        [DataMember(Name="results", EmitDefaultValue=false)]
+        public List<UserProject> Results { get; set; }
+
+        /// <summary>
+        /// The string presentation of the object.
+        /// </summary>
+        /// <returns>
+        /// The string presentation of the object.
+        /// </returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+
+}

--- a/construction/accountadmin/source/Model/UserProjectsPagination.gen.cs
+++ b/construction/accountadmin/source/Model/UserProjectsPagination.gen.cs
@@ -1,0 +1,108 @@
+/* 
+ * APS SDK
+ *
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Construction.Account.Admin
+ *
+ * The Account Admin API automates creating and managing projects, assigning and managing project users, and managing member and partner company directories. You can also synchronize data with external systems. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Autodesk.Construction.AccountAdmin.Model
+{
+    /// <summary>
+    /// User Projects Pagination
+    /// </summary>
+    [DataContract]
+    public partial class UserProjectsPagination 
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProjectsPagination" /> class.
+        /// </summary>
+        public UserProjectsPagination()
+        { }
+        
+        /// <summary>
+        /// The number of items per page.
+        /// </summary>
+        /// <value>
+        /// The number of items per page.
+        /// </value>
+        [DataMember(Name="limit", EmitDefaultValue=false)]
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// The page number that the results begin from.
+        /// </summary>
+        /// <value>
+        /// The page number that the results begin from.
+        /// </value>
+        [DataMember(Name="offset", EmitDefaultValue=false)]
+        public int? Offset { get; set; }
+
+        /// <summary>
+        /// The number of items in the response.
+        /// </summary>
+        /// <value>
+        /// The number of items in the response.
+        /// </value>
+        [DataMember(Name="totalResults", EmitDefaultValue=false)]
+        public int? TotalResults { get; set; }
+
+        /// <summary>
+        /// The URL for the next page of records.
+        /// Max length: 2000
+        /// </summary>
+        /// <value>
+        /// The URL for the next page of records.
+        /// Max length: 2000
+        /// </value>
+        [DataMember(Name="nextUrl", EmitDefaultValue=false)]
+        public string NextUrl { get; set; }
+
+        /// <summary>
+        /// The URL for the previous page of records.
+        /// Max length: 2000
+        /// </summary>
+        /// <value>
+        /// The URL for the previous page of records.
+        /// Max length: 2000
+        /// </value>
+        [DataMember(Name="previousUrl", EmitDefaultValue=false)]
+        public string PreviousUrl { get; set; }
+
+        /// <summary>
+        /// The string presentation of the object.
+        /// </summary>
+        /// <returns>
+        /// The string presentation of the object.
+        /// </returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+
+}

--- a/construction/accountadmin/source/custom-code/AdminClient.cs
+++ b/construction/accountadmin/source/custom-code/AdminClient.cs
@@ -14,6 +14,7 @@ namespace Autodesk.Construction.AccountAdmin
                 public ICompaniesApi CompaniesApi { get; }
                 public IAccountUsersApi AccountUsersApi { get; }
                 public IBusinessUnitsApi BusinessUnitsApi { get; }
+                public IUserProjectsApi UserProjectsApi { get; }
 
                 public AdminClient( SDKManager.SDKManager sdkManager = default, IAuthenticationProvider authenticationProvider = default): base(authenticationProvider)
                 {
@@ -25,6 +26,7 @@ namespace Autodesk.Construction.AccountAdmin
                         this.CompaniesApi = new CompaniesApi(sdkManager);
                         this.AccountUsersApi = new AccountUsersApi(sdkManager);
                         this.BusinessUnitsApi = new BusinessUnitsApi(sdkManager);
+                        this.UserProjectsApi = new UserProjectsApi(sdkManager);
                 }
                 
                 /// <summary>
@@ -1083,6 +1085,86 @@ namespace Autodesk.Construction.AccountAdmin
                                 accessToken = await this.AuthenticationProvider.GetAccessToken();
                         }
                         var response = await this.BusinessUnitsApi.GetBusinessUnitsAsync(accountId, region, accessToken, throwOnError);
+                        return response.Content;
+                }
+      
+                /// <summary>
+                /// Get projects of user in account.
+                /// </summary>
+                /// <remarks>
+                /// Retrieves a list of the projects in the specified account.
+                /// </remarks>
+                /// <exception cref="HttpRequestException">
+                /// Thrown when fails to make API call.
+                /// </exception>
+                /// <param name="accountId">
+                /// The ID of the ACC account that contains the project being created or the projects being retrieved. This corresponds to the hub ID in the Data Management API. To convert a hub ID into an account ID, remove the “b.” prefix. For example, a hub ID of b.c8b0c73d-3ae9 translates to an account ID of c8b0c73d-3ae9.
+                /// </param>
+                /// <param name="acceptLanguage">
+                /// This header is not currently supported in the Account Admin API. (optional)
+                /// </param>
+                /// <param name="region">
+                /// The region where the bucket resides. Acceptable values: US, EMEA, AUS. (optional)
+                /// </param>
+                /// <param name="userId">
+                /// Note that this header is not relevant for Account Admin GET endpoints. The ID of a user on whose behalf your API request is acting. Required if you’re using a 2-legged authentication context, which must be 2-legged OAuth2 security with user impersonation.  Your app has access to all users specified by the administrator in the SaaS integrations UI. Provide this header value to identify the user to be affected by the request.  You can use either the user’s ACC ID (id), or their Autodesk ID (autodeskId). (optional)
+                /// </param>
+                /// <param name="filterId">
+                /// A list of the ACC IDs of users to retrieve. (optional)
+                /// </param>
+                /// <param name="fields">
+                /// A comma-separated list of the project fields to include in the response. Default value: all fields. (optional)
+                /// </param>
+                /// <param name="filterClassification">
+                /// A list of the classifications of projects to include in the response. Possible values: production, template, component, sample. (optional)
+                /// </param>
+                /// <param name="filterName">
+                /// A project name or name pattern to filter projects by. Can be a partial match based on the value of filterTextMatch that you provide; for example: filter[name]=ABCco filterTextMatch=startsWith.  Max length: 255 (optional)
+                /// </param>
+                /// <param name="filterPlatform">
+                /// Filter resource by platform. Possible values: acc and bim360. (optional)
+                /// </param>
+                /// <param name="filterStatus">
+                /// A list of the statuses of projects to include in the response. Possible values:  active, pending, archived, suspended. (optional)
+                /// </param>
+                /// <param name="filterType">
+                /// A list of project types to filter projects by. To exclude a project type from the response, prefix it with - (a hyphen); for example, -Bridge excludes bridge projects. (optional)
+                /// </param>
+                /// <param name="filterJobNumber">
+                /// The user-defined identifier for a project to be returned. This ID was defined when the project was created. This filter accepts a partial match based on the value of filterTextMatch that you provide. (optional)
+                /// </param>
+                /// <param name="filterUpdatedAt">
+                /// A range of dates during which the desired projects were updated. The range must be specified with dates in ISO 8601 format with time required. Separate multiple values with commas. (optional)
+                /// </param>
+                /// <param name="filterAccessLevels">
+                ///A list of user access levels that the returned users must have. (optional)
+                /// </param>
+                /// <param name="filterTextMatch">
+                /// When filtering on a text-based field, this value indicates how to do the matching. Default value: contains. Possible values: contains, startsWith, endsWith and equals. (optional)
+                /// </param>
+                /// <param name="sort">
+                /// A list of fields to sort the returned projects by. Multiple sort fields are applied in sequence order — each sort field produces groupings of projects with the same values of that field; the next sort field applies within the groupings produced by the previous sort field. (optional)
+                /// </param>
+                /// <param name="limit">
+                ///The maximum number of records to return in a single request. Possible range: 1-200. Default value: 20. (optional)
+                /// </param>
+                /// <param name="offset">
+                /// The record number that the returned page should start with. When the total number of records exceeds the value of limit, increase the offset value in subsequent requests to continue getting the remaining results. (optional)
+                /// </param>
+                /// <returns>
+                /// <see cref="System.Threading.Tasks.Task"/>&lt;<see cref="UserProjects"/>&gt;
+                /// </returns>
+                public async System.Threading.Tasks.Task<UserProjects> GetUserProjectsAsync(string accountId, string acceptLanguage = default, Region? region = null, string userId = default, List<string> filterId = default, List<Fields> fields = default, List<Classification> filterClassification = default, string filterName = default, List<Platform> filterPlatform = default, List<Status> filterStatus = default, List<string> filterType = default, string filterJobNumber = default, string filterUpdatedAt = default, List<AccessLevels> filterAccessLevels = default, FilterTextMatch? filterTextMatch = null, List<SortBy> sort = default, int? limit = default, int? offset = default, string accessToken = null, bool throwOnError = true)
+                {
+                        if (string.IsNullOrEmpty(accessToken) && this.AuthenticationProvider == null)
+                        {
+                                throw new Exception("Please provide a valid access token or an authentication provider");
+                        }
+                        else if (string.IsNullOrEmpty(accessToken))
+                        {
+                                accessToken = await this.AuthenticationProvider.GetAccessToken();
+                        }
+                        var response = await this.UserProjectsApi.GetUserProjectsAsync(accountId, acceptLanguage, region, userId, filterId, fields, filterClassification, filterName, filterPlatform, filterStatus, filterType,  filterJobNumber, filterUpdatedAt, filterAccessLevels, filterTextMatch, sort, limit, offset, accessToken, throwOnError);
                         return response.Content;
                 }
         }

--- a/construction/accountadmin/test/Autodesk.Construction.AccountAdmin.Test.csproj
+++ b/construction/accountadmin/test/Autodesk.Construction.AccountAdmin.Test.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<RootNamespace>Autodesk.Construction.Issues.Test</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="coverlet.collector" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\source\Autodesk.Construction.AccountAdmin.csproj"/>
+	</ItemGroup>
+	
+</Project>

--- a/construction/accountadmin/test/TestAccountAdminApi.cs
+++ b/construction/accountadmin/test/TestAccountAdminApi.cs
@@ -1,0 +1,34 @@
+﻿using Autodesk.Construction.AccountAdmin.Model;
+using Autodesk.SDKManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Autodesk.Construction.AccountAdmin.Test;
+
+[TestClass]
+public class TestAccountAdminApi
+{
+    private static AdminClient _adminClient = null!;
+    
+    string? token = Environment.GetEnvironmentVariable("token");
+    string? accountId = Environment.GetEnvironmentVariable("account_id");
+    string? userId = Environment.GetEnvironmentVariable("user_id");
+       
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+	     var sdkManager = SdkManagerBuilder
+	     .Create()
+	     .Add(new ApsConfiguration())
+	     .Add(ResiliencyConfiguration.CreateDefault())
+	     .Build();
+        
+	     _adminClient = new AdminClient(sdkManager);
+    }
+    
+    [TestMethod]
+    public async Task TestGetUserProjectsAsync()
+    {
+	     UserProjects userProjects = await _adminClient.GetUserProjectsAsync(accessToken: token, accountId: accountId, userId: userId);
+	     Assert.IsInstanceOfType(userProjects.Results, typeof(List<UserProject>));
+    }
+}


### PR DESCRIPTION
Add support for the new 'User Projects' Account Admin API referenced in the Autodesk blog post & documentation below.

Blog Post:
[ACC Admin API: new API to list all projects for a specified user](https://aps.autodesk.com/blog/acc-admin-api-new-api-list-all-projects-specified-user)

Documentation:
[GET users/:user_id/projects](https://aps.autodesk.com/en/docs/acc/v1/reference/http/admin-usersuseridprojects-GET/)