### PR TITLE
Add Missing Namespace Declarations To SDK Manager.

### DIFF
--- a/sdkmanager/src/BaseClient.cs
+++ b/sdkmanager/src/BaseClient.cs
@@ -1,25 +1,27 @@
-public class BaseClient
+namespace Autodesk.SDKManager
 {
-    private IAuthenticationProvider _authenticationProvider;
-
-    public IAuthenticationProvider AuthenticationProvider
+   public class BaseClient
     {
-        get
-        {
-            return _authenticationProvider;
-        }
-        set
-        {
-            _authenticationProvider = value;
-        }
-    }
+        private IAuthenticationProvider _authenticationProvider;
 
-    public BaseClient(IAuthenticationProvider authenticationProvider)
-    {
-        if (authenticationProvider != null)
+        public IAuthenticationProvider AuthenticationProvider
         {
-            _authenticationProvider = authenticationProvider;
+            get
+            {
+                return _authenticationProvider;
+            }
+            set
+            {
+                _authenticationProvider = value;
+            }
         }
 
+        public BaseClient(IAuthenticationProvider authenticationProvider)
+        {
+            if (authenticationProvider != null)
+            {
+                _authenticationProvider = authenticationProvider;
+            }
+        }
     }
 }

--- a/sdkmanager/src/IAuthenticationProvider.cs
+++ b/sdkmanager/src/IAuthenticationProvider.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-public interface IAuthenticationProvider
+namespace Autodesk.SDKManager
 {
-       Task<string> GetAccessToken(IEnumerable<string> scopes = default);
+    public interface IAuthenticationProvider
+    {
+        Task<string> GetAccessToken(IEnumerable<string> scopes = default);
+    }
 }

--- a/sdkmanager/src/StaticAuthenticationProvider.cs
+++ b/sdkmanager/src/StaticAuthenticationProvider.cs
@@ -1,20 +1,20 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-public class StaticAuthenticationProvider : IAuthenticationProvider
+namespace Autodesk.SDKManager
 {
-    private string _accessToken;
-
-    public StaticAuthenticationProvider(string accessToken)
+    public class StaticAuthenticationProvider : IAuthenticationProvider
     {
-        _accessToken = accessToken;
+        private string _accessToken;
+
+        public StaticAuthenticationProvider(string accessToken)
+        {
+            _accessToken = accessToken;
+        }
+
+        public async Task<string> GetAccessToken(IEnumerable<string> scopes = default)
+        {
+            return _accessToken;
+        }
     }
-
-
-    public async Task<string> GetAccessToken(IEnumerable<string> scopes = default)
-    {
-        return _accessToken;
-    }
-
-
 }


### PR DESCRIPTION
# Reason
- Resolve #220.

# Changes
- Added 'Namespace' declaration at top of classes in SDK Manager.