### PR TITLE
Add `Project.TemplateId` property to ACC Project.

### DIFF
--- a/construction/accountadmin/source/Model/Project.gen.cs
+++ b/construction/accountadmin/source/Model/Project.gen.cs
@@ -383,7 +383,7 @@ namespace Autodesk.Construction.AccountAdmin.Model
         /// <value>
         ///The ID of the project that was used as a template to create this project.
         /// </value>
-        [DataMember(Name= "templateId", EmitDefaultValue=false)]
+        [DataMember(Name="templateId", EmitDefaultValue=false)]
         public string? TemplateId { get; set; }
 
         /// <summary>

--- a/construction/accountadmin/source/Model/Project.gen.cs
+++ b/construction/accountadmin/source/Model/Project.gen.cs
@@ -56,11 +56,11 @@ namespace Autodesk.Construction.AccountAdmin.Model
 
         /// <summary>
         ///The name of the project.
-///Max length: 255
+        ///Max length: 255
         /// </summary>
         /// <value>
         ///The name of the project.
-///Max length: 255
+        ///Max length: 255
         /// </value>
         [DataMember(Name="name", EmitDefaultValue=false)]
         public string Name { get; set; }
@@ -121,33 +121,33 @@ namespace Autodesk.Construction.AccountAdmin.Model
 
         /// <summary>
         ///A job identifier that’s defined for the project by the user. This ID was defined when the project was created.
-///Max length: 100
+        ///Max length: 100
         /// </summary>
         /// <value>
         ///A job identifier that’s defined for the project by the user. This ID was defined when the project was created.
-///Max length: 100
+        ///Max length: 100
         /// </value>
         [DataMember(Name="jobNumber", EmitDefaultValue=false)]
         public string JobNumber { get; set; }
 
         /// <summary>
         ///Address line 1 for the project.
-///Max length: 255
+        ///Max length: 255
         /// </summary>
         /// <value>
         ///Address line 1 for the project.
-///Max length: 255
+        ///Max length: 255
         /// </value>
         [DataMember(Name="addressLine1", EmitDefaultValue=false)]
         public string AddressLine1 { get; set; }
 
         /// <summary>
         ///Address line 2 for the project.
-///Max length: 255
+        ///Max length: 255
         /// </summary>
         /// <value>
         ///Address line 2 for the project.
-///Max length: 255
+        ///Max length: 255
         /// </value>
         [DataMember(Name="addressLine2", EmitDefaultValue=false)]
         public string AddressLine2 { get; set; }
@@ -376,6 +376,15 @@ namespace Autodesk.Construction.AccountAdmin.Model
         /// </value>
         [DataMember(Name="memberCount", EmitDefaultValue=false)]
         public int? MemberCount { get; set; }
+
+        /// <summary>
+        ///The ID of the project that was used as a template to create this project.
+        /// </summary>
+        /// <value>
+        ///The ID of the project that was used as a template to create this project.
+        /// </value>
+        [DataMember(Name= "templateId", EmitDefaultValue=false)]
+        public string? TemplateId { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/construction/accountadmin/test/TestAccountAdminApi.cs
+++ b/construction/accountadmin/test/TestAccountAdminApi.cs
@@ -11,6 +11,7 @@ public class TestAccountAdminApi
     
     string? token = Environment.GetEnvironmentVariable("token");
     string? accountId = Environment.GetEnvironmentVariable("account_id");
+    string? projectId = Environment.GetEnvironmentVariable("project_id");
     string? userId = Environment.GetEnvironmentVariable("user_id");
        
     [ClassInitialize]
@@ -23,6 +24,20 @@ public class TestAccountAdminApi
 	     .Build();
         
 	     _adminClient = new AdminClient(sdkManager);
+    }
+    
+    [TestMethod]
+    public async Task TestGetProjectAsync()
+    {
+	     Project project = await _adminClient.GetProjectAsync(accessToken: token, projectId: projectId);
+        Assert.IsTrue(projectId == project.Id);
+    }
+    
+    [TestMethod]
+    public async Task TestGetProjectsAsync()
+    {
+	     ProjectsPage projectsPage = await _adminClient.GetProjectsAsync(accessToken: token, accountId: accountId);
+	     Assert.IsInstanceOfType(projectsPage.Results, typeof(List<Project>));
     }
     
     [TestMethod]


### PR DESCRIPTION
# About

Add support for the `TemplateId` property on ACC Projects.

# Changes

- Added `TemplateId` property to the [Project](https://github.com/autodesk-platform-services/aps-sdk-net/blob/e144a0187267865789262d497a91f81be0b248a8/construction/accountadmin/source/Model/Project.gen.cs#L39) class.
- Added `TestGetProjectAsync` & `TestGetProjectsAsync` in the [TestAccountAdminApi](https://github.com/autodesk-platform-services/aps-sdk-net/blob/main/construction/accountadmin/test/TestAccountAdminApi.cs) class to test changes.

# Testing

``` csharp
[TestMethod]
public async Task TestGetProjectAsync()
{
	Project project = await _adminClient.GetProjectAsync(accessToken: token, projectId: projectId);
   Assert.IsTrue(projectId == project.Id);
}
    
[TestMethod]
public async Task TestGetProjectsAsync()
{
	ProjectsPage projectsPage = await _adminClient.GetProjectsAsync(accessToken: token, accountId: accountId);
	Assert.IsInstanceOfType(projectsPage.Results, typeof(List<Project>));
}
```

# References

- [ACC Project TemplateId - Documentation](https://aps.autodesk.com/en/docs/acc/v1/reference/http/admin-accounts-accountidprojects-GET/#body-structure-200)
- [ACC Project TemplateId - Blog Post](https://aps.autodesk.com/blog/templateid-field-added-acc-projects-related-apis-identify-template-project-created)

## Methods:

- AdminClient
  - [GetProjectAsync()](https://github.com/autodesk-platform-services/aps-sdk-net/blob/e144a0187267865789262d497a91f81be0b248a8/construction/accountadmin/source/custom-code/AdminClient.cs#L92)
  - [GetProjectsAsync()](https://github.com/autodesk-platform-services/aps-sdk-net/blob/e144a0187267865789262d497a91f81be0b248a8/construction/accountadmin/source/custom-code/AdminClient.cs#L203)
- ProjectsApi
  - [GetProjectAsync()](https://github.com/autodesk-platform-services/aps-sdk-net/blob/e144a0187267865789262d497a91f81be0b248a8/construction/accountadmin/source/Http/ProjectsApi.gen.cs#L518)
  - [GetProjectsAsync()](https://github.com/autodesk-platform-services/aps-sdk-net/blob/e144a0187267865789262d497a91f81be0b248a8/construction/accountadmin/source/Http/ProjectsApi.gen.cs#L662)
  
## Data

- Sample data from Postman request to show inclusion of `TemplateId` with & without value.
``` json
[
	{
		...
		"templateId": null,
		...
	},
	{
		...
		"templateId": "a00a0aa0-bb00-0c00-dd00-e00000e00e00",
		...
	}
]
```