### PR TITLE
Refactor WriteToFileStreamFromUrl to use await

### DIFF
--- a/oss/source/custom-code/OSSFileTransfer.cs
+++ b/oss/source/custom-code/OSSFileTransfer.cs
@@ -409,10 +409,10 @@ namespace Autodesk.Oss
             string requestId)
         {
             _forgeService.Client.DefaultRequestHeaders.Add("Range", "bytes=" + start + "-" + end);
-            var streamAsync = _forgeService.Client.GetByteArrayAsync(contentUrl);
+            var bytes = await _forgeService.Client.GetByteArrayAsync(contentUrl);
             _forgeService.Client.DefaultRequestHeaders.Remove("Range");
-            var available = streamAsync.Result.Length;
-            await outStream.WriteAsync(streamAsync.Result, 0, available);
+            var available = bytes.Length;
+            await outStream.WriteAsync(bytes, 0, available);
         }
 
         private string HandleRequestId(string parentRequestId, string bucketKey, string objectKey)


### PR DESCRIPTION
Fixes UI blocking caused by sync wait on async call

The original implementation called .Result on GetByteArrayAsync, which synchronously blocks UI threads (WPF, Winforms) while waiting for the HTTP request to complete.

This change replaces the synchronous .Result access with proper await usage, allowing the async operation to complete without blocking the UI thread and causing deadlocks.