### PR TITLE
Corrected type declaration in Issues Sample & Test.

### DIFF
--- a/construction/issues/test/TestIssuesApi.cs
+++ b/construction/issues/test/TestIssuesApi.cs
@@ -40,8 +40,8 @@ public class TestIssuesApi
     [TestMethod]
     public async Task getIssueType()
     {
-        IssueTypesPage Type = await issuesClient.GetIssuesTypesAsync(projectid, xAdsRegion: Region.US, accessToken: token);
-        Assert.AreNotSame(Type.Pagination, null);
+        IssueTypesPage types = await issuesClient.GetIssuesTypesAsync(projectid, xAdsRegion: Region.US, accessToken: token);
+        Assert.AreNotSame(types.Pagination, null);
     }
 
     [TestMethod]

--- a/construction/issues/test/TestIssuesApi.cs
+++ b/construction/issues/test/TestIssuesApi.cs
@@ -40,7 +40,7 @@ public class TestIssuesApi
     [TestMethod]
     public async Task getIssueType()
     {
-        TypesPage Type = await issuesClient.GetIssuesTypesAsync(projectid, xAdsRegion: Region.US, accessToken: token);
+        IssueTypesPage Type = await issuesClient.GetIssuesTypesAsync(projectid, xAdsRegion: Region.US, accessToken: token);
         Assert.AreNotSame(Type.Pagination, null);
     }
 
@@ -79,7 +79,7 @@ public class TestIssuesApi
     {
         CommentsPayload newcomment = new CommentsPayload();
         newcomment.Body = "<Body>";
-        Comments createComment = await issuesClient.CreateCommentsAsync(projectid, issueId, xAdsRegion: Region.US, commentsPayload: newcomment, accessToken: token);
+        Comment createComment = await issuesClient.CreateCommentsAsync(projectid, issueId, xAdsRegion: Region.US, commentsPayload: newcomment, accessToken: token);
         Assert.AreNotSame(createComment.Id, null);
 
 

--- a/samples/issues.cs
+++ b/samples/issues.cs
@@ -33,7 +33,7 @@ namespace Samples
         // Get IssueType
         public async Task getIssueType()
         {
-            IssueTypesPage Type = await issuesClient.GetIssuesTypesAsync(projectId: project_id);
+            IssueTypesPage types = await issuesClient.GetIssuesTypesAsync(projectId: project_id);
         }
 
         //Get Issues

--- a/samples/issues.cs
+++ b/samples/issues.cs
@@ -33,7 +33,7 @@ namespace Samples
         // Get IssueType
         public async Task getIssueType()
         {
-            IssueType Type = await issuesClient.GetIssuesTypesAsync(projectId: project_id);
+            IssueTypesPage Type = await issuesClient.GetIssuesTypesAsync(projectId: project_id);
         }
 
         //Get Issues
@@ -67,19 +67,19 @@ namespace Samples
         {
             CommentsPayload newcomment = new CommentsPayload();
             newcomment.Body = "Created a Comment for testing SDK";
-            CreatedComment createComment = await issuesClient.CreateCommentsAsync(projectId: project_id, issueId: issue_id, commentsPayload: newcomment);
+            Comment createComment = await issuesClient.CreateCommentsAsync(projectId: project_id, issueId: issue_id, commentsPayload: newcomment);
         }
 
         //Get Comments
         public async Task getComments()
         {
-            Comments getComments = await issuesClient.GetCommentsAsync(projectId: project_id, issueId: issue_id);
+            CommentsPage getComments = await issuesClient.GetCommentsAsync(projectId: project_id, issueId: issue_id);
             Console.WriteLine(getComments);
         }
 
         public async Task getAttrdefinition()
         {
-            AttrDefinition attrDefinition = await issuesClient.GetAttributeDefinitionsAsync(projectId: project_id);
+            AttrDefinitionPage attrDefinition = await issuesClient.GetAttributeDefinitionsAsync(projectId: project_id);
             Console.WriteLine(attrDefinition);
         }
 


### PR DESCRIPTION
**Reason**
- Incorrect types declared from IssuesClient usage in Issues Sample & Test, causing build errors.

**Changes**
- Corrected issuesClient.GetIssuesTypesAsync() type from IssueType to IssueTypesPage.
- Corrected issuesClient.CreateCommentsAsync() type from Comments to Comment.
- Corrected issuesClient.CreateCommentsAsync() type from CreatedComment to Comment.
- Corrected issuesClient.GetCommentsAsync() type from CreatedComment to Comment.
- Corrected issuesClient.GetAttributeDefinitionsAsync() type from AttrDefinitionto AttrDefinitionPage.

**References**
- [IssuesClient](https://github.com/autodesk-platform-services/aps-sdk-net/blob/main/construction/issues/source/custom-code/IssuesClient.cs)