### PR TITLE
Add ProtectBucketAsync() implementation & test to OSS client.

### DIFF
--- a/oss/source/Http/BucketsApi.gen.cs
+++ b/oss/source/Http/BucketsApi.gen.cs
@@ -24,17 +24,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Runtime.Serialization;
-using System.Threading.Channels;
 using Autodesk.Forge.Core;
 using Autodesk.Oss.Client;
 using Autodesk.Oss.Model;
-using Autodesk.SDKManager;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Autodesk.Oss.Http
 {
@@ -660,7 +654,7 @@ namespace Autodesk.Oss.Http
                 }
                 else if (!response.IsSuccessStatusCode)
                 {
-                    logger.LogError($"Response unsuccess with status code: {response.StatusCode}.");
+                    logger.LogError($"Response unsuccessful with status code: {response.StatusCode}.");
                     return response;
                 }
                 logger.LogInformation($"Exited from {nameof(ProtectBucketAsync)}() with response statusCode: {response.StatusCode}.");

--- a/oss/source/Http/BucketsApi.gen.cs
+++ b/oss/source/Http/BucketsApi.gen.cs
@@ -20,18 +20,21 @@
  * limitations under the License.
  */
 
-using Autodesk.Forge.Core;
-using Microsoft.Extensions.Options;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Runtime.Serialization;
-using Autodesk.Oss.Model;
+using System.Threading.Channels;
+using Autodesk.Forge.Core;
 using Autodesk.Oss.Client;
+using Autodesk.Oss.Model;
+using Autodesk.SDKManager;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Autodesk.SDKManager;
+using Microsoft.Extensions.Options;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Autodesk.Oss.Http
 {
@@ -134,6 +137,39 @@ namespace Autodesk.Oss.Http
         /// <returns>Task of ApiResponse&lt;Buckets&gt;</returns>
 
         System.Threading.Tasks.Task<ApiResponse<Buckets>> GetBucketsAsync(Region? region = null, int? limit = default(int?), string startAt = default(string), string accessToken = null, bool throwOnError = true);
+
+        /// <summary>
+        /// Protect Bucket
+        /// </summary>
+        /// <remarks>
+        /// Modifies the protection status of the specified bucket.
+        /// When you protect a bucket, it cannot be deleted until you explicitly unprotect it.
+        /// When you unprotect a bucket, it becomes eligible for deletion again.
+        /// 
+        /// You must be the owner of the bucket or have appropriate permissions to modify bucket protection settings.
+        /// 
+        /// This operation is idempotent.
+        /// Protecting an already protected bucket or unprotecting an already unprotected bucket will not result in an error.
+        /// 
+        /// The protection status change takes effect immediately upon successful completion of the operation.
+        /// </remarks>
+        /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
+        /// <param name="bucketKey">
+        /// The bucket key of the bucket to protect.
+        /// </param>
+        /// <param name="payload">
+        /// The request payload for the Protect Bucket operation.
+        /// </param>
+        /// <param name="accessToken">
+        /// An access token obtained by a call to GetThreeLeggedTokenAsync() or GetTwoLeggedTokenAsync().
+        /// (optional)
+        /// </param>
+        /// <param name="throwOnError">
+        /// Specifies whether to throw an error if the API call fails.
+        /// (optional)
+        /// </param>
+        /// <returns>Task of <see cref="HttpResponseMessage"/></returns>
+        System.Threading.Tasks.Task<HttpResponseMessage> ProtectBucketAsync(string bucketKey, ProtectBucketPayload payload, string accessToken = null, bool throwOnError = true);
     }
 
     /// <summary>
@@ -244,7 +280,7 @@ namespace Autodesk.Oss.Http
         /// </param>
         /// <returns>Task of ApiResponse&lt;Bucket&gt;></returns>
 
-        public async System.Threading.Tasks.Task<ApiResponse<Bucket>> CreateBucketAsync(CreateBucketsPayload policyKey, Region xAdsRegion , string accessToken = null, bool throwOnError = true)
+        public async System.Threading.Tasks.Task<ApiResponse<Bucket>> CreateBucketAsync(CreateBucketsPayload policyKey, Region xAdsRegion, string accessToken = null, bool throwOnError = true)
         {
             logger.LogInformation("Entered into CreateBucketAsync ");
             using (var request = new HttpRequestMessage())
@@ -552,6 +588,84 @@ namespace Autodesk.Oss.Http
                 return new ApiResponse<Buckets>(response, await LocalMarshalling.DeserializeAsync<Buckets>(response.Content));
 
             } // using
+        }
+
+        /// <summary>
+        /// Protect Bucket
+        /// </summary>
+        /// <remarks>
+        /// Modifies the protection status of the specified bucket.
+        /// When you protect a bucket, it cannot be deleted until you explicitly unprotect it.
+        /// When you unprotect a bucket, it becomes eligible for deletion again.
+        /// 
+        /// You must be the owner of the bucket or have appropriate permissions to modify bucket protection settings.
+        /// 
+        /// This operation is idempotent.
+        /// Protecting an already protected bucket or unprotecting an already unprotected bucket will not result in an error.
+        /// 
+        /// The protection status change takes effect immediately upon successful completion of the operation.
+        /// </remarks>
+        /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
+        /// <param name="bucketKey">
+        /// The bucket key of the bucket to protect.
+        /// </param>
+        /// <param name="payload">
+        /// The request payload for the Protect Bucket operation.
+        /// </param>
+        /// <param name="accessToken">
+        /// An access token obtained by a call to GetThreeLeggedTokenAsync() or GetTwoLeggedTokenAsync().
+        /// (optional)
+        /// </param>
+        /// <param name="throwOnError">
+        /// Specifies whether to throw an error if the API call fails.
+        /// (optional)
+        /// </param>
+        /// <returns>Task of <see cref="HttpResponseMessage"/></returns>
+        public async System.Threading.Tasks.Task<HttpResponseMessage> ProtectBucketAsync(string bucketKey, ProtectBucketPayload payload, string accessToken = null, bool throwOnError = true)
+        {
+            logger.LogInformation($"Entered into {nameof(ProtectBucketAsync)}().");
+            using (var request = new HttpRequestMessage())
+            {
+                var queryParam = new Dictionary<string, object>();
+                request.RequestUri =
+                    Marshalling.BuildRequestUri("/oss/v2/buckets/{bucketKey}/protect",
+                        routeParameters: new Dictionary<string, object> {
+                            { "bucketKey", bucketKey},
+                        },
+                        queryParameters: queryParam
+                    );
+
+                request.Headers.TryAddWithoutValidation("Accept", "application/json");
+                request.Headers.TryAddWithoutValidation("User-Agent", "APS SDK/OSS/C#/1.0.0");
+                if (!string.IsNullOrEmpty(accessToken))
+                {
+                    request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+                }
+
+                request.Content = Marshalling.Serialize(payload);
+                request.Method = new HttpMethod("POST");
+
+                HttpResponseMessage response = await Service.Client.SendAsync(request);
+
+                if (throwOnError)
+                {
+                    try
+                    {
+                        await response.EnsureSuccessStatusCodeAsync();
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        throw new OssApiException(ex.Message, response, ex);
+                    }
+                }
+                else if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogError($"Response unsuccess with status code: {response.StatusCode}.");
+                    return response;
+                }
+                logger.LogInformation($"Exited from {nameof(ProtectBucketAsync)}() with response statusCode: {response.StatusCode}.");
+                return response;
+            }
         }
     }
 }

--- a/oss/source/Model/ProtectBucketPayload.gen.cs
+++ b/oss/source/Model/ProtectBucketPayload.gen.cs
@@ -1,0 +1,74 @@
+/* 
+ * APS SDK
+ *
+ * The APS Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * oss
+ *
+ * The Object Storage Service (OSS) allows your application to download and upload raw files (such as PDF, XLS, DWG, or RVT) that are managed by the Data service.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Autodesk.Oss.Model
+{
+    /// <summary>
+    /// The request payload for the Protect Bucket operation.
+    /// </summary>
+    [DataContract]
+    public partial class ProtectBucketPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtectBucketPayload" /> class.
+        /// </summary>
+        public ProtectBucketPayload()
+        { }
+
+        /// <summary>
+        /// Indicates the protection status of the bucket. Possible values are:
+        /// 
+        /// - `true` - Protects the bucket from accidental deletion.
+        /// - `false` - Leaves the bucket unprotected or removes protection from a previously protected bucket.
+        /// </summary>
+        /// <value>
+        /// Indicates the protection status of the bucket. Possible values are:
+        /// 
+        /// - `true` - Protects the bucket from accidental deletion.
+        /// - `false` - Leaves the bucket unprotected or removes protection from a previously protected bucket.
+        /// </value>
+        [DataMember(Name = "protection", EmitDefaultValue = true)]
+        public bool Protection { get; set; }
+
+        /// <summary>
+        /// Returns the string presentation of the object.
+        /// </summary>
+        /// <returns>
+        /// String presentation of the object.
+        /// </returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+}

--- a/oss/source/Model/ProtectBucketPayload.gen.cs
+++ b/oss/source/Model/ProtectBucketPayload.gen.cs
@@ -20,16 +20,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.IO;
-using System.Text;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Autodesk.Oss.Model
 {

--- a/oss/source/custom-code/OssClient.cs
+++ b/oss/source/custom-code/OssClient.cs
@@ -818,6 +818,52 @@ namespace Autodesk.Oss
             var response = await this.bucketsApi.GetBucketsAsync(region, limit, startAt, accessToken, throwOnError);
             return response.Content;
         }
+
+        /// <summary>
+        /// Protect Bucket
+        /// </summary>
+        /// <remarks>
+        /// Modifies the protection status of the specified bucket.
+        /// When you protect a bucket, it cannot be deleted until you explicitly unprotect it.
+        /// When you unprotect a bucket, it becomes eligible for deletion again.
+        /// 
+        /// You must be the owner of the bucket or have appropriate permissions to modify bucket protection settings.
+        /// 
+        /// This operation is idempotent.
+        /// Protecting an already protected bucket or unprotecting an already unprotected bucket will not result in an error.
+        /// 
+        /// The protection status change takes effect immediately upon successful completion of the operation.
+        /// </remarks>
+        /// <exception cref="HttpRequestException">Thrown when fails to make API call</exception>
+        /// <param name="bucketKey">
+        /// The bucket key of the bucket to protect.
+        /// </param>
+        /// <param name="payload">
+        /// The request payload for the Protect Bucket operation.
+        /// </param>
+        /// <param name="accessToken">
+        /// An access token obtained by a call to GetThreeLeggedTokenAsync() or GetTwoLeggedTokenAsync().
+        /// (optional)
+        /// </param>
+        /// <param name="throwOnError">
+        /// Specifies whether to throw an error if the API call fails.
+        /// (optional)
+        /// </param>
+        /// <returns>Task of <see cref="HttpResponseMessage"/></returns>
+        public async System.Threading.Tasks.Task<HttpResponseMessage> ProtectBucketAsync(string bucketKey, ProtectBucketPayload payload, string accessToken = null, bool throwOnError = true)
+        {
+            if (string.IsNullOrEmpty(accessToken) && AuthenticationProvider == null)
+            {
+                throw new Exception("Please provide a valid access token or an authentication provider.");
+            }
+            else if (string.IsNullOrEmpty(accessToken))
+            {
+                accessToken = await AuthenticationProvider.GetAccessToken();
+            }
+            var response = await bucketsApi.ProtectBucketAsync(bucketKey, payload, accessToken, throwOnError);
+            return response;
+        }
+
         /// <summary>
         /// Get Object Details
         /// </summary>

--- a/oss/source/custom-code/OssClient.cs
+++ b/oss/source/custom-code/OssClient.cs
@@ -850,7 +850,7 @@ namespace Autodesk.Oss
         /// (optional)
         /// </param>
         /// <returns>Task of <see cref="HttpResponseMessage"/></returns>
-        public async System.Threading.Tasks.Task<HttpResponseMessage> ProtectBucketAsync(string bucketKey, ProtectBucketPayload payload, string accessToken = null, bool throwOnError = true)
+        public async System.Threading.Tasks.Task<HttpResponseMessage> ProtectBucketAsync(string bucketKey, ProtectBucketPayload payload, string accessToken = default, bool throwOnError = true)
         {
             if (string.IsNullOrEmpty(accessToken) && AuthenticationProvider == null)
             {

--- a/oss/test/TestOss.cs
+++ b/oss/test/TestOss.cs
@@ -77,6 +77,19 @@ public class TestOss
 		Assert.IsTrue(httpResponseMessage.StatusCode == HttpStatusCode.OK);
 	}
 
+	[TestMethod]
+	public async Task TestProtectBucketAsync()
+	{
+		HttpResponseMessage httpResponseMessage = await _ossClient.ProtectBucketAsync(
+			 accessToken: token,
+			 bucketKey: bucketKey,
+             payload: new()
+             {
+                 Protection = false,
+             });
+		Assert.IsTrue(httpResponseMessage.StatusCode == HttpStatusCode.OK);
+	}
+
 	#endregion
 
 	#region Objects

--- a/oss/test/TestOss.cs
+++ b/oss/test/TestOss.cs
@@ -85,7 +85,7 @@ public class TestOss
 			 bucketKey: bucketKey,
              payload: new()
              {
-                 Protection = false,
+                 Protection = true,
              });
 		Assert.IsTrue(httpResponseMessage.StatusCode == HttpStatusCode.OK);
 	}


### PR DESCRIPTION
Add ProtectBucketAsync() implementation & test to OSS client.

[Prevent Bucket Deletion - Blog Post](https://aps.autodesk.com/blog/prevent-bucket-deletion)
[OSS Protect Bucket - Documentation](https://aps.autodesk.com/en/docs/data/v2/reference/http/post-oss-v2-buckets-bucketkey-pr-POST/)