### PR TITLE
Fixed intermittent NullReferenceException during concurrent uploads.

### DIFF
--- a/oss/source/Autodesk.Oss.csproj
+++ b/oss/source/Autodesk.Oss.csproj
@@ -6,11 +6,11 @@
     <Authors>Autodesk Platform Services SDK Team</Authors>
     <PackageDescription>Client SDK for Data Management OSS API</PackageDescription>
     <PackageReleaseNotes>
-    • Added XadsMeta properties to Upload function. 
+    • Fixed intermittent NullReferenceException during concurrent uploads.
     </PackageReleaseNotes>
     <Copyright>Autodesk Inc.</Copyright>
     <PackageId>Autodesk.Oss</PackageId>
-    <PackageVersion>2.3.3</PackageVersion>
+    <PackageVersion>2.3.4</PackageVersion>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>autodesk-icon.png</PackageIcon>

--- a/oss/source/custom-code/OSSFileTransfer.cs
+++ b/oss/source/custom-code/OSSFileTransfer.cs
@@ -177,7 +177,7 @@ namespace Autodesk.Oss
                         {
                             ThrowIfCancellationRequested(cancellationToken, requestId);
 
-                            var responseBuffer = await UploadToURL(currentUrl, fileBytes);
+                            var responseBuffer = await UploadToURL(currentUrl, fileBytes, requestId);
                             int statusCode = (int)responseBuffer.StatusCode;
 
                             if (statusCode == (int)HttpStatusCode.Forbidden && retryUrlExpiryCount == _maxRetryOnUrlExpiry)
@@ -312,11 +312,14 @@ namespace Autodesk.Oss
             return numberOfChunks;
         }
 
-        private async Task<dynamic> UploadToURL(string url, byte[] buffer)
+        private async Task<HttpResponseMessage> UploadToURL(string url, byte[] buffer, string requestId)
         {
-            var client = new HttpClient();
-            var httpContent = new ByteArrayContent(buffer);
-            return await _forgeService.Client.PutAsync(url, httpContent);
+            using var request = new HttpRequestMessage(HttpMethod.Put, url)
+            {
+                Content = new ByteArrayContent(buffer)
+            };
+            request.Headers.Add("x-ads-request-id", requestId);
+            return await _forgeService.Client.SendAsync(request);
         }
 
         public async Task<Stream> Download(string bucketKey, string objectKey,
@@ -408,24 +411,19 @@ namespace Autodesk.Oss
         private async Task WriteToFileStreamFromUrl(Stream outStream, string contentUrl, double start, double end,
             string requestId)
         {
-            _forgeService.Client.DefaultRequestHeaders.Add("Range", "bytes=" + start + "-" + end);
-            var streamAsync = _forgeService.Client.GetByteArrayAsync(contentUrl);
-            _forgeService.Client.DefaultRequestHeaders.Remove("Range");
-            var available = streamAsync.Result.Length;
-            await outStream.WriteAsync(streamAsync.Result, 0, available);
+            using var request = new HttpRequestMessage(HttpMethod.Get, contentUrl);
+            request.Headers.Add("Range", "bytes=" + start + "-" + end);
+
+            var response = await _forgeService.Client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            await outStream.WriteAsync(bytes, 0, bytes.Length);
         }
 
         private string HandleRequestId(string parentRequestId, string bucketKey, string objectKey)
         {
             var requestId = !string.IsNullOrEmpty(parentRequestId) ? parentRequestId : Guid.NewGuid().ToString();
             requestId = requestId + ":" + GenerateSdkRequestId(bucketKey, objectKey);
-
-            if (_forgeService.Client.DefaultRequestHeaders.Contains("x-ads-request-id"))
-            {
-                _forgeService.Client.DefaultRequestHeaders.Remove("x-ads-request-id");
-            }
-
-            _forgeService.Client.DefaultRequestHeaders.Add("x-ads-request-id", requestId);
             return requestId;
         }
 


### PR DESCRIPTION
This pull request addresses reliability issues with concurrent uploads and refactors how HTTP headers are managed for upload and download operations in the OSS client. The main focus is to fix an intermittent `NullReferenceException` during concurrent uploads by ensuring per-request header handling, rather than modifying shared client headers.

**Bug fix and reliability improvements:**

* Fixed an intermittent `NullReferenceException` that could occur during concurrent uploads by refactoring header management and ensuring request-specific headers are set on individual HTTP requests instead of the shared `HttpClient` instance.

**Refactoring and code improvements:**

* Updated `UploadToURL` to accept a `requestId` parameter and set the `"x-ads-request-id"` header on each HTTP request, preventing header collisions between concurrent requests. [[1]](diffhunk://#diff-c697c5b556c48d1338168a9a92826ab0e83a119da754577c7cfdb32463d428b1L180-R180) [[2]](diffhunk://#diff-c697c5b556c48d1338168a9a92826ab0e83a119da754577c7cfdb32463d428b1L315-R322)
* Refactored the download logic in `WriteToFileStreamFromUrl` to set the `"Range"` header on individual requests instead of modifying the shared client headers, improving thread safety.
* Removed code that added or removed the `"x-ads-request-id"` header on the shared `HttpClient`, as this is now handled per request.

**Versioning:**

* Bumped the package version from `2.3.3` to `2.3.4` to reflect the bug fix and improvements.